### PR TITLE
handle booleans from any json class

### DIFF
--- a/lib/Net/Stripe/Simple.pm
+++ b/lib/Net/Stripe/Simple.pm
@@ -628,7 +628,7 @@ sub _encode_params {
             }
         } else {
             $value =    # JSON boolean stringification magic has been erased
-              ref $value eq 'JSON::PP::Boolean'
+              blessed $value && $value->isa(ref(true())) # hack to work around inheritance issues with JSON booleans
               ? $value
                   ? 'true'
                   : 'false'
@@ -871,7 +871,7 @@ B<Available Actions>
             customer => $customer,
             amount   => 100,
             currency => 'usd',
-            capture  => 'false',
+            capture  => false,
         }
     );
 


### PR DESCRIPTION
I took a second look at RT [#100274](https://rt.cpan.org/Ticket/Display.html?id=100274), and this actually looks like a bug with how JSON::true()/false() are encoded. The ref for JSON booleans depends
on which JSON backend is loaded, as well as the version of JSON.

Not sure if this was the best solution, but you can see in the JSON [changelog](https://metacpan.org/changes/distribution/JSON) that JSON boolean inheritance has been a bit of a mess.